### PR TITLE
replace `fs.mkdir` with `mkdirSync` for node v10+

### DIFF
--- a/lib/attachmentWriter.js
+++ b/lib/attachmentWriter.js
@@ -10,7 +10,7 @@ function attachmentWriter(program){
     const dir = getFileDir(program.source);
     const attachmentDir = dir + '/attachments';
     if(!fsExistsSync(attachmentDir)) {
-        fs.mkdir(attachmentDir);
+        fs.mkdirSync(attachmentDir);
     }
     const zip = new JSZip(fs.readFileSync(program.source));
     _.forIn(zip.files, (file, filename) => {


### PR DESCRIPTION
at v10.0.0 The `callback` parameter in `fs.mkdir` is no longer optional